### PR TITLE
common: fix wrong down casting in _tx_thread_create

### DIFF
--- a/common/src/tx_thread_create.c
+++ b/common/src/tx_thread_create.c
@@ -121,7 +121,7 @@ ALIGN_TYPE              updated_stack_start;
 
     /* Ensure the starting stack address is evenly aligned.  */
     new_stack_start =  TX_POINTER_TO_ALIGN_TYPE_CONVERT(stack_start);
-    updated_stack_start =  ((((ULONG) new_stack_start) + ((sizeof(ULONG)) - ((ULONG) 1)) ) & (~((sizeof(ULONG)) - ((ULONG) 1))));
+    updated_stack_start =  (( (new_stack_start) + ((sizeof(ULONG)) - ((ULONG) 1)) ) & (~((sizeof(ULONG)) - ((ULONG) 1))));
 
     /* Determine if the starting stack address is different.  */
     if (new_stack_start != updated_stack_start)


### PR DESCRIPTION
casting new_stack_start to ULONG can result in the wrong start address when running on 64-bit 
machines (e.g. gnu/linux) as it zeroes the higher address bits. The correct type is ALIGN_TYPE, since 
both new_stack_start and updated_stack_start are ALIGN_TYPE the casting can be simply removed 
and this change should have no effect on 32-bit machines.